### PR TITLE
Don't run platform specific code in editor

### DIFF
--- a/Assets/Plugins/AppsFlyer.cs
+++ b/Assets/Plugins/AppsFlyer.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 public class AppsFlyer : MonoBehaviour {
 	
 	
-	#if UNITY_IOS
+	#if UNITY_IOS && !UNITY_EDITOR
 	[DllImport("__Internal")]
 	private static extern void mTrackEvent(string eventName,string eventValue);
 	
@@ -114,7 +114,7 @@ public class AppsFlyer : MonoBehaviour {
 		mHandleOpenUrl (url, sourceApplication, annotation);
 	}
 	
-	#elif UNITY_ANDROID
+	#elif UNITY_ANDROID && !UNITY_EDITOR
 	private static AndroidJavaClass cls_AppsFlyer = new AndroidJavaClass("com.appsflyer.AppsFlyerLib");
 	private static AndroidJavaClass cls_AppsFlyerHelper = new AndroidJavaClass("com.appsflyer.AppsFlyerUnityHelper");
 	


### PR DESCRIPTION
had an issue running our app in editor on android settings - UNITY_ANDROID is true even when run from the editor